### PR TITLE
Mark Broadcast::isAvailable method as deprecated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,6 @@ require __DIR__ . '/vendor/autoload.php';
 
 $broadcast = new Broadcast(RPC::create('tcp://127.0.0.1:6001'));
 
-if (!$broadcast->isAvailable()) {
-    throw new \LogicException('The [broadcast] plugin not available');
-}
-
 //
 // Now we can send a message to a specific topic
 //

--- a/src/Broadcast.php
+++ b/src/Broadcast.php
@@ -38,24 +38,11 @@ final class Broadcast implements BroadcastInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Information about RoadRunner plugins is not available since RoadRunner version 2.2
      */
     public function isAvailable(): bool
     {
-        try {
-            /** @var array<string>|mixed $result */
-            $result = $this->rpc
-                ->withCodec(new JsonCodec())
-                ->call('informer.List', true);
-
-            if (! \is_array($result)) {
-                return false;
-            }
-
-            return \in_array('websockets', $result, true);
-        } catch (\Throwable $e) {
-            return false;
-        }
+        throw new \RuntimeException(\sprintf('%s::isAvailable method is deprecated.', self::class));
     }
 
     /**

--- a/src/BroadcastInterface.php
+++ b/src/BroadcastInterface.php
@@ -21,13 +21,6 @@ use Spiral\RoadRunner\Broadcast\Exception\InvalidArgumentException;
 interface BroadcastInterface
 {
     /**
-     * Returns information about whether a broadcast plugin is available.
-     *
-     * @return bool
-     */
-    public function isAvailable(): bool;
-
-    /**
      * Method to send messages to the required topic (channel).
      * <code>
      *  $broadcast->publish('topic', 'message');

--- a/tests/BroadcastTestCase.php
+++ b/tests/BroadcastTestCase.php
@@ -37,29 +37,10 @@ class BroadcastTestCase extends TestCase
 
     public function testIsAvailable(): void
     {
-        $factory = $this->broadcast(['informer.List' => '["websockets"]']);
-        $this->assertTrue($factory->isAvailable());
-    }
+        $this->expectException(\RuntimeException::class);
+        $this->expectErrorMessage('Spiral\RoadRunner\Broadcast\Broadcast::isAvailable method is deprecated.');
 
-    public function testNotAvailable(): void
-    {
-        $factory = $this->broadcast(['informer.List' => '[]']);
-        $this->assertFalse($factory->isAvailable());
-    }
-
-    public function testNotAvailableOnNonArrayResponse(): void
-    {
-        $factory = $this->broadcast(['informer.List' => '42']);
-        $this->assertFalse($factory->isAvailable());
-    }
-
-    public function testNotAvailableOnErrorResponse(): void
-    {
-        $factory = $this->broadcast(['informer.List' => (static function () {
-            throw new \Exception();
-        })]);
-
-        $this->assertFalse($factory->isAvailable());
+        $this->broadcast()->isAvailable();
     }
 
     public function testPublishingSingleMessage(): void


### PR DESCRIPTION
Since RoadRunner version 2.3 there is not an ability to get list of available plugins via RPC and every time when developers started using this package they bumped into a problem with `Broadcast::isAvailable` method. With this PR the method was marked as a deprecated and now it will throw an exception with information about deprecation.